### PR TITLE
Feat: show dummy data if api failed

### DIFF
--- a/components/Adds/FAQ/FAQPage.tsx
+++ b/components/Adds/FAQ/FAQPage.tsx
@@ -18,7 +18,7 @@ export default function FAQPage() {
 
 	return (
 		<S.FAQPageLayout>
-			{faqs &&
+			{faqs ? (
 				faqs.items.map((faq, i) => (
 					<FAQBoxElement
 						idx={faq.id + 1}
@@ -27,7 +27,19 @@ export default function FAQPage() {
 						answer={faq.reply}
 						key={i}
 					/>
-				))}
+				))
+			) : (
+				<FAQBoxElement
+					idx={0 + 1}
+					category={'OOOOOO프로젝트'}
+					question={
+						'OOOOOO프로젝트에 참여하는 사람입니다.\n하루에 세 번 OOOO을 하라고 안내 받았는데, 놓친 날이 있다면 어떻게 해야할까요?'
+					}
+					answer={
+						'OOOOOO프로젝트에 참여하시는 분들은 하루에 세 번 OOOO을 하시기를 권장드립니다.\n그러나 놓친 날이 있는 경우엔 데일리 설문조사에서 놓친 날짜, 시간에 대한 정보를 꼭 기입해주시기 바랍니다.\n혹시 설문조사에서 쓰지 않은 경우엔 reaiqwhl@yonsei.ac.kr로 연락 주세요.'
+					}
+				/>
+			)}
 		</S.FAQPageLayout>
 	);
 }


### PR DESCRIPTION
ADDS FAQ 더미데이터
- 백에 https 설정이 되어있지않아 api 요청 시 오류 발생
- mixed content 허용 메타태그를 적용해봤으나 해결되지 않았음
- 찾아보니 백에 ssl 인증서가 존재하지 않으면 메타태그로도 해결안된다고 함
- 브라우저에서 일시적으로 안전한 요청 옵션을 끄는 방법이 있음
- api 요청 실패 시 더미 데이터 보여주게 함