### PR TITLE
Fix: padding bottom for faq answer box so that letters do not overflow

### DIFF
--- a/components/Adds/FAQ/FAQPage.tsx
+++ b/components/Adds/FAQ/FAQPage.tsx
@@ -120,6 +120,7 @@ namespace S {
 			/* 토글 */
 			> pre:last-of-type {
 				overflow: hidden;
+				padding-bottom: 0.2rem;
 				margin-bottom: ${(props) => (props.isOpen ? '2.6rem' : '0')};
 				transition: 0.3s ease;
 			}


### PR DESCRIPTION
ADDS FAQ
- 답변 열었을 때 일부 문자가 overflow 되지 않도록 미세한 패딩 줌